### PR TITLE
feat: expose fetcher helpers as functions

### DIFF
--- a/src/utils/Fetcher.ts
+++ b/src/utils/Fetcher.ts
@@ -14,7 +14,11 @@ import {
 } from './FetcherConfiguration'
 
 export class Fetcher {
-  constructor(private readonly customDefaults?: Omit<RequestOptions, 'body'>) {}
+  private readonly customDefaults: Omit<RequestOptions, 'body'>
+
+  constructor(customDefaults?: Omit<RequestOptions, 'body'>) {
+    this.customDefaults = customDefaults ?? {}
+  }
 
   fetchJson(url: string, options?: RequestOptions): Promise<any> {
     return fetchJson(url, mergeRequestOptions(this.customDefaults, options))

--- a/src/utils/Fetcher.ts
+++ b/src/utils/Fetcher.ts
@@ -88,7 +88,7 @@ async function copyResponse(response: Response, writeTo: ReadableStream<Uint8Arr
   return response.headers
 }
 
-async function postForm(url: string, options?: RequestOptions): Promise<any> {
+export async function postForm(url: string, options?: RequestOptions): Promise<any> {
   return fetchInternal(url, response => response.json(), mergeRequestOptions(POST_DEFAULTS, options))
 }
 

--- a/src/utils/Helper.ts
+++ b/src/utils/Helper.ts
@@ -55,6 +55,6 @@ export function mergeRequestOptions<T = CompleteRequestOptions | RequestOptions>
     ...(target as RequestOptions)?.headers,
     ...source?.headers
   }
-  const combinedOptions: T = applyDefaults(target ?? ({} as T), source)
+  const combinedOptions: T = applyDefaults(target, source)
   return { ...combinedOptions, headers: combinedHeaders }
 }

--- a/src/utils/Helper.ts
+++ b/src/utils/Helper.ts
@@ -2,7 +2,7 @@ import ms from 'ms'
 import { CompleteRequestOptions, RequestOptions } from './FetcherConfiguration'
 
 export function delay(time: string): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms(time)))
+  return new Promise(resolve => setTimeout(resolve, ms(time)))
 }
 
 export async function retry<T>(
@@ -52,9 +52,9 @@ export function mergeRequestOptions<T = CompleteRequestOptions | RequestOptions>
   source?: RequestOptions
 ): T {
   const combinedHeaders: Record<string, string> = {
-    ...(target as RequestOptions).headers,
+    ...(target as RequestOptions)?.headers,
     ...source?.headers
   }
-  const combinedOptions: T = applyDefaults(target, source)
+  const combinedOptions: T = applyDefaults(target ?? ({} as T), source)
   return { ...combinedOptions, headers: combinedHeaders }
 }


### PR DESCRIPTION
Even though it makes sense to have the `Fetcher` object in some cases (like the content server), in others, it doesn't. And having to create a `Fetcher` object to call the methods doesn't make much sense, so we are now supporting both.

The idea is that the `Fetcher` class will internally call the functions, that have the same behaviour as before